### PR TITLE
chore: update browserslist db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -566,16 +566,6 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
-    "node_modules/@babel/helper-compilation-targets/node_modules/caniuse-lite": {
-      "version": "1.0.30001284",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz",
-      "integrity": "sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw==",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
-    },
     "node_modules/@babel/helper-compilation-targets/node_modules/electron-to-chromium": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.11.tgz",
@@ -4591,10 +4581,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001214",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
-      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
-      "dev": true
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -14104,12 +14098,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001284",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001284.tgz",
-          "integrity": "sha512-t28SKa7g6kiIQi6NHeOcKrOrGMzCRrXvlasPwWC26TH2QNdglgzQIRUuJ0cR3NeQPH+5jpuveeeSFDLm2zbkEw==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.4.11",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.11.tgz",
@@ -17196,9 +17184,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001214",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001214.tgz",
-      "integrity": "sha512-O2/SCpuaU3eASWVaesQirZv1MSjUNOvmugaD8zNSJqw6Vv5SGwoOpA9LJs3pNPfM745nxqPvfZY3MQKY4AKHYg==",
+      "version": "1.0.30001299",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001299.tgz",
+      "integrity": "sha512-iujN4+x7QzqA2NCSrS5VUy+4gLmRd4xv6vbBBsmfVqTx8bLAD8097euLqQgKxSVLvxjSDcvF1T/i9ocgnUFexw==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
```bash
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating
Latest version:     1.0.30001299
Installed versions: 1.0.30001214, 1.0.30001284
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@angular-devkit/core@13.0.2',
npm WARN EBADENGINE   required: {
npm WARN EBADENGINE     node: '^12.20.0 || ^14.15.0 || >=16.10.0',
npm WARN EBADENGINE     npm: '^6.11.0 || ^7.5.6 || >=8.0.0',
npm WARN EBADENGINE     yarn: '>= 1.13.0'
npm WARN EBADENGINE   },
npm WARN EBADENGINE   current: { node: 'v16.5.0', npm: '7.19.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@angular-devkit/schematics@13.0.2',
npm WARN EBADENGINE   required: {
npm WARN EBADENGINE     node: '^12.20.0 || ^14.15.0 || >=16.10.0',
npm WARN EBADENGINE     npm: '^6.11.0 || ^7.5.6 || >=8.0.0',
npm WARN EBADENGINE     yarn: '>= 1.13.0'
npm WARN EBADENGINE   },
npm WARN EBADENGINE   current: { node: 'v16.5.0', npm: '7.19.1' }
npm WARN EBADENGINE }
Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@angular-devkit/core@13.0.2',
npm WARN EBADENGINE   required: {
npm WARN EBADENGINE     node: '^12.20.0 || ^14.15.0 || >=16.10.0',
npm WARN EBADENGINE     npm: '^6.11.0 || ^7.5.6 || >=8.0.0',
npm WARN EBADENGINE     yarn: '>= 1.13.0'
npm WARN EBADENGINE   },
npm WARN EBADENGINE   current: { node: 'v16.5.0', npm: '7.19.1' }
npm WARN EBADENGINE }
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@angular-devkit/schematics@13.0.2',
npm WARN EBADENGINE   required: {
npm WARN EBADENGINE     node: '^12.20.0 || ^14.15.0 || >=16.10.0',
npm WARN EBADENGINE     npm: '^6.11.0 || ^7.5.6 || >=8.0.0',
npm WARN EBADENGINE     yarn: '>= 1.13.0'
npm WARN EBADENGINE   },
npm WARN EBADENGINE   current: { node: 'v16.5.0', npm: '7.19.1' }
npm WARN EBADENGINE }
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 90
+ and_chr 96
- and_ff 87
+ and_ff 95
- android 90
+ android 96
- chrome 90
- chrome 89
- chrome 88
- chrome 87
+ chrome 97
+ chrome 96
+ chrome 95
+ chrome 94
- edge 90
- edge 89
- edge 88
+ edge 97
+ edge 96
- firefox 87
- firefox 86
+ firefox 96
+ firefox 95
+ firefox 94
- ios_saf 14.0-14.5
- ios_saf 13.4-13.7
+ ios_saf 15.2
+ ios_saf 15.0-15.1
+ ios_saf 14.5-14.8
+ ios_saf 14.0-14.4
+ ios_saf 12.2-12.5
- op_mob 62
+ op_mob 64
- opera 75
- opera 74
+ opera 82
+ opera 81
- safari 14
+ safari 15.2
+ safari 15.1
+ safari 14.1
- samsung 13.0
- samsung 12.0
+ samsung 15.0
+ samsung 14.0
```