### PR TITLE
feat(deps): support NestJS 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 > ⚠️ If you want to use @narando/nest-axios-interceptor with NestJS Version 6 or 7,
 > please use the v1 release.
 >
-> The v2 release is only compatible with NestJS Version 8 and @nestjs/axios package.
+> The v2 release is only compatible with NestJS Versions 8 and 9 and @nestjs/axios package.
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
-        "@nestjs/axios": "0.0.8",
-        "@nestjs/cli": "8.2.8",
-        "@nestjs/common": "8.4.7",
-        "@nestjs/core": "8.4.7",
-        "@nestjs/schematics": "8.0.11",
-        "@nestjs/testing": "8.4.7",
+        "@nestjs/axios": "0.1.0",
+        "@nestjs/cli": "9.0.0",
+        "@nestjs/common": "9.0.3",
+        "@nestjs/core": "9.0.3",
+        "@nestjs/schematics": "9.0.1",
+        "@nestjs/testing": "9.0.3",
         "@types/express": "4.17.13",
         "@types/jest": "27.5.2",
         "@types/node": "16.11.43",
@@ -37,28 +37,27 @@
         "typescript": "4.5.5"
       },
       "peerDependencies": {
-        "@nestjs/axios": ">=0.0.5 <=0.0.8",
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0",
+        "@nestjs/axios": ">=0.0.5 <=0.1.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.6.tgz",
-      "integrity": "sha512-ZmD586B+RnM2CG5+jbXh2NVfIydTc/yKSjppYDDOv4I530YBm6vpfZMwClpiNk6XLbMv7KqX4Tlr4wfxlPYYbA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.0.5.tgz",
+      "integrity": "sha512-/CUGi6QLwh79FvsOY7M+1LQL3asZsbQW/WBd5f1iu5y7TLNqCwo+wOb0ZXLDNPw45vYBxFajtt3ob3U7qx3jNg==",
       "dev": true,
       "dependencies": {
-        "ajv": "8.9.0",
+        "ajv": "8.11.0",
         "ajv-formats": "2.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
+        "jsonc-parser": "3.0.0",
         "rxjs": "6.6.7",
         "source-map": "0.7.3"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "node": "^14.15.0 || >=16.10.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       },
@@ -72,9 +71,9 @@
       }
     },
     "node_modules/@angular-devkit/core/node_modules/ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -106,49 +105,49 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.6.tgz",
-      "integrity": "sha512-yLh5xc92C/FiaAp27coPiKWpSUmwoXF7vMxbJYJTyOXlt0mUITAEAwtrZQNr4yAxW/yvgTdyg7PhXaveQNTUuQ==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.0.5.tgz",
+      "integrity": "sha512-sufxITBkn2MvgEREt9JQ3QCKHS+sue1WsVzLE+TWqG5MC/RPk0f9tQ5VoHk6ZTzDKUvOtSoc7G+n0RscQsyp5g==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "13.3.6",
+        "@angular-devkit/core": "14.0.5",
         "jsonc-parser": "3.0.0",
-        "magic-string": "0.25.7",
+        "magic-string": "0.26.1",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "node": "^14.15.0 || >=16.10.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/schematics-cli": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-13.3.6.tgz",
-      "integrity": "sha512-5tTuu9gbXM0bMk0sin4phmWA3U1Qz53zT/rpEfzQ/+c/s8CoqZ5N1qOnYtemRct3Jxsz1kn4TBpHeriR4r5hHg==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-14.0.5.tgz",
+      "integrity": "sha512-S+u0KjglyI3jEZWwIuBvFjEwY3Zk5lCWfhet+95sFKJEjEYgF4Fuk8Mau/9cr55hIcpZqTQUvyxnS/VDoj4WLg==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "13.3.6",
-        "@angular-devkit/schematics": "13.3.6",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
         "ansi-colors": "4.1.1",
-        "inquirer": "8.2.0",
-        "minimist": "1.2.6",
-        "symbol-observable": "4.0.0"
+        "inquirer": "8.2.4",
+        "symbol-observable": "4.0.0",
+        "yargs-parser": "21.0.1"
       },
       "bin": {
         "schematics": "bin/schematics.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+        "node": "^14.15.0 || >=16.10.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/inquirer": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+      "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^4.2.1",
@@ -161,13 +160,23 @@
         "mute-stream": "0.0.8",
         "ora": "^5.4.1",
         "run-async": "^2.4.0",
-        "rxjs": "^7.2.0",
+        "rxjs": "^7.5.5",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
-        "through": "^2.3.6"
+        "through": "^2.3.6",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
@@ -1218,29 +1227,29 @@
       }
     },
     "node_modules/@nestjs/axios": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
-      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.1.0.tgz",
+      "integrity": "sha512-b2TT2X6BFbnNoeteiaxCIiHaFcSbVW+S5yygYqiIq5i6H77yIU3IVuLdpQkHq8/EqOWFwMopLN8jdkUT71Am9w==",
       "dev": true,
       "dependencies": {
         "axios": "0.27.2"
       },
       "peerDependencies": {
-        "@nestjs/common": "^7.0.0 || ^8.0.0",
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@nestjs/cli": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-8.2.8.tgz",
-      "integrity": "sha512-y5Imcw1EY0OxD3POAM7SLUB1rFdn5FjbfSsyJrokjKmXY+i6KcBdbRrv3Ox7aeJ4W7wXuckIXZEUlK6lC52dnA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.0.0.tgz",
+      "integrity": "sha512-xT5uOoIEcaB/Fn6UeF7atfKqKiEEsTeRKPiM55p+e5H9WVw8FC2r4ceZgaINJbsw0QWskVj/ZQadMo6dA6hXxw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "13.3.6",
-        "@angular-devkit/schematics": "13.3.6",
-        "@angular-devkit/schematics-cli": "13.3.6",
-        "@nestjs/schematics": "^8.0.3",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
+        "@angular-devkit/schematics-cli": "14.0.5",
+        "@nestjs/schematics": "^9.0.0",
         "chalk": "3.0.0",
         "chokidar": "3.5.3",
         "cli-table3": "0.6.2",
@@ -1264,8 +1273,7 @@
         "nest": "bin/nest.js"
       },
       "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 6.11.0"
+        "node": ">= 12.9.0"
       }
     },
     "node_modules/@nestjs/cli/node_modules/chalk": {
@@ -1307,12 +1315,11 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.7.tgz",
-      "integrity": "sha512-m/YsbcBal+gA5CFrDpqXqsSfylo+DIQrkFY3qhVIltsYRfu8ct8J9pqsTO6OPf3mvqdOpFGrV5sBjoyAzOBvsw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.3.tgz",
+      "integrity": "sha512-QPUdWb6srXmJeRlnavLa0FHFXtgajm/WsyYn/MlHpzqTv7VRfB/zLicwPofdH+CozVvzoZp+c63Khuysg9uasw==",
       "dev": true,
       "dependencies": {
-        "axios": "0.27.2",
         "iterare": "1.2.1",
         "tslib": "2.4.0",
         "uuid": "8.3.2"
@@ -1347,9 +1354,9 @@
       "dev": true
     },
     "node_modules/@nestjs/core": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
-      "integrity": "sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-TFXCfcqt1FqN/54hrrfdLZgAroDjqbkJ8mDcFiD4JFuQGIHkgofXXEtjfwPAEfR41RLxB8612Pf0UjI4bag4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1366,10 +1373,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/microservices": "^8.0.0",
-        "@nestjs/platform-express": "^8.0.0",
-        "@nestjs/websockets": "^8.0.0",
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/microservices": "^9.0.0",
+        "@nestjs/platform-express": "^9.0.0",
+        "@nestjs/websockets": "^9.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
@@ -1392,104 +1399,25 @@
       "dev": true
     },
     "node_modules/@nestjs/schematics": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-8.0.11.tgz",
-      "integrity": "sha512-W/WzaxgH5aE01AiIErE9QrQJ73VR/M/8p8pq0LZmjmNcjZqU5kQyOWUxZg13WYfSpJdOa62t6TZRtFDmgZPoIg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-9.0.1.tgz",
+      "integrity": "sha512-QU7GbnQvADFXdumcdADmv4vil3bhnYl2IFHWKieRt0MgIhghgBxIB7kDKWhswcuZ0kZztVbyYjo9aCrlf62fcw==",
       "dev": true,
       "dependencies": {
-        "@angular-devkit/core": "13.3.5",
-        "@angular-devkit/schematics": "13.3.5",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
         "fs-extra": "10.1.0",
         "jsonc-parser": "3.0.0",
         "pluralize": "8.0.0"
       },
       "peerDependencies": {
-        "typescript": "^3.4.5 || ^4.3.5"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/@angular-devkit/core": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.5.tgz",
-      "integrity": "sha512-w7vzK4VoYP9rLgxJ2SwEfrkpKybdD+QgQZlsDBzT0C6Ebp7b4gkNcNVFo8EiZvfDl6Yplw2IAP7g7fs3STn0hQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "8.9.0",
-        "ajv-formats": "2.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
-        "rxjs": "6.6.7",
-        "source-map": "0.7.3"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^3.5.2"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/@angular-devkit/schematics": {
-      "version": "13.3.5",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.5.tgz",
-      "integrity": "sha512-0N/kL/Vfx0yVAEwa3HYxNx9wYb+G9r1JrLjJQQzDp+z9LtcojNf7j3oey6NXrDUs1WjVZOa/AIdRl3/DuaoG5w==",
-      "dev": true,
-      "dependencies": {
-        "@angular-devkit/core": "13.3.5",
-        "jsonc-parser": "3.0.0",
-        "magic-string": "0.25.7",
-        "ora": "5.4.1",
-        "rxjs": "6.6.7"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
-        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
-        "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/ajv": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@nestjs/schematics/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
-    },
-    "node_modules/@nestjs/schematics/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "typescript": "^4.3.5"
       }
     },
     "node_modules/@nestjs/testing": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.4.7.tgz",
-      "integrity": "sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.3.tgz",
+      "integrity": "sha512-6pLtQLblbBOukiABR6ty2HOpW2Z1lUJmP3mqKVFc11n7ZoF5kDxYaDTxdbMlcynye8eH7ehRvzsGnNJJmLlaSA==",
       "dev": true,
       "dependencies": {
         "tslib": "2.4.0"
@@ -1499,10 +1427,10 @@
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^8.0.0",
-        "@nestjs/core": "^8.0.0",
-        "@nestjs/microservices": "^8.0.0",
-        "@nestjs/platform-express": "^8.0.0"
+        "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
+        "@nestjs/microservices": "^9.0.0",
+        "@nestjs/platform-express": "^9.0.0"
       },
       "peerDependenciesMeta": {
         "@nestjs/microservices": {
@@ -2373,9 +2301,9 @@
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-      "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2662,20 +2590,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2911,9 +2825,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
-      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2960,7 +2874,7 @@
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -3187,7 +3101,7 @@
     "node_modules/defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
@@ -5636,12 +5550,15 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
+      "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
       "dev": true,
       "dependencies": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -7458,7 +7375,7 @@
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
@@ -7775,23 +7692,22 @@
   },
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.6.tgz",
-      "integrity": "sha512-ZmD586B+RnM2CG5+jbXh2NVfIydTc/yKSjppYDDOv4I530YBm6vpfZMwClpiNk6XLbMv7KqX4Tlr4wfxlPYYbA==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-14.0.5.tgz",
+      "integrity": "sha512-/CUGi6QLwh79FvsOY7M+1LQL3asZsbQW/WBd5f1iu5y7TLNqCwo+wOb0ZXLDNPw45vYBxFajtt3ob3U7qx3jNg==",
       "dev": true,
       "requires": {
-        "ajv": "8.9.0",
+        "ajv": "8.11.0",
         "ajv-formats": "2.1.1",
-        "fast-json-stable-stringify": "2.1.0",
-        "magic-string": "0.25.7",
+        "jsonc-parser": "3.0.0",
         "rxjs": "6.6.7",
         "source-map": "0.7.3"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -7818,14 +7734,14 @@
       }
     },
     "@angular-devkit/schematics": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.6.tgz",
-      "integrity": "sha512-yLh5xc92C/FiaAp27coPiKWpSUmwoXF7vMxbJYJTyOXlt0mUITAEAwtrZQNr4yAxW/yvgTdyg7PhXaveQNTUuQ==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-14.0.5.tgz",
+      "integrity": "sha512-sufxITBkn2MvgEREt9JQ3QCKHS+sue1WsVzLE+TWqG5MC/RPk0f9tQ5VoHk6ZTzDKUvOtSoc7G+n0RscQsyp5g==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "13.3.6",
+        "@angular-devkit/core": "14.0.5",
         "jsonc-parser": "3.0.0",
-        "magic-string": "0.25.7",
+        "magic-string": "0.26.1",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
       },
@@ -7842,23 +7758,23 @@
       }
     },
     "@angular-devkit/schematics-cli": {
-      "version": "13.3.6",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-13.3.6.tgz",
-      "integrity": "sha512-5tTuu9gbXM0bMk0sin4phmWA3U1Qz53zT/rpEfzQ/+c/s8CoqZ5N1qOnYtemRct3Jxsz1kn4TBpHeriR4r5hHg==",
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics-cli/-/schematics-cli-14.0.5.tgz",
+      "integrity": "sha512-S+u0KjglyI3jEZWwIuBvFjEwY3Zk5lCWfhet+95sFKJEjEYgF4Fuk8Mau/9cr55hIcpZqTQUvyxnS/VDoj4WLg==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "13.3.6",
-        "@angular-devkit/schematics": "13.3.6",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
         "ansi-colors": "4.1.1",
-        "inquirer": "8.2.0",
-        "minimist": "1.2.6",
-        "symbol-observable": "4.0.0"
+        "inquirer": "8.2.4",
+        "symbol-observable": "4.0.0",
+        "yargs-parser": "21.0.1"
       },
       "dependencies": {
         "inquirer": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
-          "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.4.tgz",
+          "integrity": "sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==",
           "dev": true,
           "requires": {
             "ansi-escapes": "^4.2.1",
@@ -7871,11 +7787,18 @@
             "mute-stream": "0.0.8",
             "ora": "^5.4.1",
             "run-async": "^2.4.0",
-            "rxjs": "^7.2.0",
+            "rxjs": "^7.5.5",
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0",
-            "through": "^2.3.6"
+            "through": "^2.3.6",
+            "wrap-ansi": "^7.0.0"
           }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
         }
       }
     },
@@ -8676,24 +8599,24 @@
       }
     },
     "@nestjs/axios": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.0.8.tgz",
-      "integrity": "sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.1.0.tgz",
+      "integrity": "sha512-b2TT2X6BFbnNoeteiaxCIiHaFcSbVW+S5yygYqiIq5i6H77yIU3IVuLdpQkHq8/EqOWFwMopLN8jdkUT71Am9w==",
       "dev": true,
       "requires": {
         "axios": "0.27.2"
       }
     },
     "@nestjs/cli": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-8.2.8.tgz",
-      "integrity": "sha512-y5Imcw1EY0OxD3POAM7SLUB1rFdn5FjbfSsyJrokjKmXY+i6KcBdbRrv3Ox7aeJ4W7wXuckIXZEUlK6lC52dnA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.0.0.tgz",
+      "integrity": "sha512-xT5uOoIEcaB/Fn6UeF7atfKqKiEEsTeRKPiM55p+e5H9WVw8FC2r4ceZgaINJbsw0QWskVj/ZQadMo6dA6hXxw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "13.3.6",
-        "@angular-devkit/schematics": "13.3.6",
-        "@angular-devkit/schematics-cli": "13.3.6",
-        "@nestjs/schematics": "^8.0.3",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
+        "@angular-devkit/schematics-cli": "14.0.5",
+        "@nestjs/schematics": "^9.0.0",
         "chalk": "3.0.0",
         "chokidar": "3.5.3",
         "cli-table3": "0.6.2",
@@ -8745,12 +8668,11 @@
       }
     },
     "@nestjs/common": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.7.tgz",
-      "integrity": "sha512-m/YsbcBal+gA5CFrDpqXqsSfylo+DIQrkFY3qhVIltsYRfu8ct8J9pqsTO6OPf3mvqdOpFGrV5sBjoyAzOBvsw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.0.3.tgz",
+      "integrity": "sha512-QPUdWb6srXmJeRlnavLa0FHFXtgajm/WsyYn/MlHpzqTv7VRfB/zLicwPofdH+CozVvzoZp+c63Khuysg9uasw==",
       "dev": true,
       "requires": {
-        "axios": "0.27.2",
         "iterare": "1.2.1",
         "tslib": "2.4.0",
         "uuid": "8.3.2"
@@ -8765,9 +8687,9 @@
       }
     },
     "@nestjs/core": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-8.4.7.tgz",
-      "integrity": "sha512-XB9uexHqzr2xkPo6QSiQWJJttyYYLmvQ5My64cFvWFi7Wk2NIus0/xUNInwX3kmFWB6pF1ab5Y2ZBvWdPwGBhw==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.0.3.tgz",
+      "integrity": "sha512-TFXCfcqt1FqN/54hrrfdLZgAroDjqbkJ8mDcFiD4JFuQGIHkgofXXEtjfwPAEfR41RLxB8612Pf0UjI4bag4Vw==",
       "dev": true,
       "requires": {
         "@nuxtjs/opencollective": "0.3.2",
@@ -8788,78 +8710,22 @@
       }
     },
     "@nestjs/schematics": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-8.0.11.tgz",
-      "integrity": "sha512-W/WzaxgH5aE01AiIErE9QrQJ73VR/M/8p8pq0LZmjmNcjZqU5kQyOWUxZg13WYfSpJdOa62t6TZRtFDmgZPoIg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-9.0.1.tgz",
+      "integrity": "sha512-QU7GbnQvADFXdumcdADmv4vil3bhnYl2IFHWKieRt0MgIhghgBxIB7kDKWhswcuZ0kZztVbyYjo9aCrlf62fcw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "13.3.5",
-        "@angular-devkit/schematics": "13.3.5",
+        "@angular-devkit/core": "14.0.5",
+        "@angular-devkit/schematics": "14.0.5",
         "fs-extra": "10.1.0",
         "jsonc-parser": "3.0.0",
         "pluralize": "8.0.0"
-      },
-      "dependencies": {
-        "@angular-devkit/core": {
-          "version": "13.3.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.5.tgz",
-          "integrity": "sha512-w7vzK4VoYP9rLgxJ2SwEfrkpKybdD+QgQZlsDBzT0C6Ebp7b4gkNcNVFo8EiZvfDl6Yplw2IAP7g7fs3STn0hQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "8.9.0",
-            "ajv-formats": "2.1.1",
-            "fast-json-stable-stringify": "2.1.0",
-            "magic-string": "0.25.7",
-            "rxjs": "6.6.7",
-            "source-map": "0.7.3"
-          }
-        },
-        "@angular-devkit/schematics": {
-          "version": "13.3.5",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.5.tgz",
-          "integrity": "sha512-0N/kL/Vfx0yVAEwa3HYxNx9wYb+G9r1JrLjJQQzDp+z9LtcojNf7j3oey6NXrDUs1WjVZOa/AIdRl3/DuaoG5w==",
-          "dev": true,
-          "requires": {
-            "@angular-devkit/core": "13.3.5",
-            "jsonc-parser": "3.0.0",
-            "magic-string": "0.25.7",
-            "ora": "5.4.1",
-            "rxjs": "6.6.7"
-          }
-        },
-        "ajv": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "json-schema-traverse": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
-        },
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        }
       }
     },
     "@nestjs/testing": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.4.7.tgz",
-      "integrity": "sha512-aedpeJFicTBeiTCvJWUG45WMMS53f5eu8t2fXsfjsU1t+WdDJqYcZyrlCzA4dL1B7MfbqaTURdvuVVHTmJO8ag==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-9.0.3.tgz",
+      "integrity": "sha512-6pLtQLblbBOukiABR6ty2HOpW2Z1lUJmP3mqKVFc11n7ZoF5kDxYaDTxdbMlcynye8eH7ehRvzsGnNJJmLlaSA==",
       "dev": true,
       "requires": {
         "tslib": "2.4.0"
@@ -9578,9 +9444,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.8.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-          "integrity": "sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -9798,19 +9664,6 @@
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
       }
     },
     "brace-expansion": {
@@ -9979,9 +9832,9 @@
       }
     },
     "cli-spinners": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.5.0.tgz",
-      "integrity": "sha512-PC+AmIuK04E6aeSs/pUccSujsTzBhu4HzC2dL+CfJB/Jcc2qTRbEwZQDfIUpt2Xl8BodYBEq8w4fc0kU2I9DjQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
       "dev": true
     },
     "cli-table3": {
@@ -10014,7 +9867,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
     "co": {
@@ -10206,7 +10059,7 @@
     "defaults": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -12046,12 +11899,12 @@
       "dev": true
     },
     "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.1.tgz",
+      "integrity": "sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==",
       "dev": true,
       "requires": {
-        "sourcemap-codec": "^1.4.4"
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "make-dir": {
@@ -13369,7 +13222,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -20,19 +20,19 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "peerDependencies": {
-    "@nestjs/axios": ">=0.0.5 <=0.0.8",
-    "@nestjs/common": "^8.0.0",
-    "@nestjs/core": "^8.0.0",
+    "@nestjs/axios": ">=0.0.5 <=0.1.0",
+    "@nestjs/common": "^8.0.0 || ^9.0.0",
+    "@nestjs/core": "^8.0.0 || ^9.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.0.0"
   },
   "devDependencies": {
-    "@nestjs/axios": "0.0.8",
-    "@nestjs/cli": "8.2.8",
-    "@nestjs/common": "8.4.7",
-    "@nestjs/core": "8.4.7",
-    "@nestjs/schematics": "8.0.11",
-    "@nestjs/testing": "8.4.7",
+    "@nestjs/axios": "0.1.0",
+    "@nestjs/cli": "9.0.0",
+    "@nestjs/common": "9.0.3",
+    "@nestjs/core": "9.0.3",
+    "@nestjs/schematics": "9.0.1",
+    "@nestjs/testing": "9.0.3",
     "@types/express": "4.17.13",
     "@types/jest": "27.5.2",
     "@types/node": "16.11.43",


### PR DESCRIPTION
Add support for NestJS 9 by bumping our `devDependencies` and add the new major version to the `peerDependencies`. None of the changes mentioned in the [migration guide](https://docs.nestjs.com/migration-guide) apply to this library.