### PR TITLE
ci: fix semantic-release branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,5 +5,10 @@
     "@semantic-release/npm",
     "@semantic-release/git"
   ],
-  "repositoryUrl": "https://github.com/narando/nest-axios-interceptor"
+  "repositoryUrl": "https://github.com/narando/nest-axios-interceptor",
+  "branches": [
+    "main",
+    {"name": "beta", "prerelease": true},
+    {"name": "alpha", "prerelease": true}
+  ]
 }


### PR DESCRIPTION
I recently renamed `master` to `main`, but the [default for semantic-release only contains `master`](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#branches).